### PR TITLE
MAN-1167: remove date-fns rule

### DIFF
--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -88,10 +88,6 @@ module.exports = {
             message: "Please import { faker } from '@faker-js/faker/locale/en' instead due to performance issues",
             name: '@faker-js/faker',
           },
-          {
-            message: "Please use more specific import: import format from 'date-fns/format'",
-            name: 'date-fns',
-          },
         ],
         patterns: [
           {


### PR DESCRIPTION
Removing `date-fns` rule due it's not needed anymore due [this other PR](https://git.yexir.com/landbot/landbot/-/merge_requests/1721#note_127391)