### PR TITLE
feat(eslint): add plugin to avoid barrel files

### DIFF
--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -53,7 +53,7 @@ module.exports = {
     project: './services/*/tsconfig.json',
     sourceType: 'module',
   },
-  plugins: ['react', '@typescript-eslint', 'import', 'jest'],
+  plugins: ['react', '@typescript-eslint', 'import', 'jest', 'eslint-plugin-barrel-files'],
   root: true,
   rules: {
     '@typescript-eslint/no-unused-vars': [
@@ -95,6 +95,12 @@ module.exports = {
             message: "Please import analytics from 'core/analytics' instead",
           },
         ],
+      },
+    ],
+    'barrel-files/avoid-barrel-files': [
+      2,
+      {
+        amountOfExportsToConsiderModuleAsBarrel: 50,
       },
     ],
   },

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -13,6 +13,7 @@
         "@typescript-eslint/eslint-plugin": "^8.4.0",
         "@typescript-eslint/parser": "^8.4.0",
         "eslint": "^8.57.0",
+        "eslint-plugin-barrel-files": "^2.1.0",
         "eslint-plugin-import": "^2.30.0",
         "eslint-plugin-jest": "^28.8.2",
         "eslint-plugin-react": "^7.35.1",
@@ -278,6 +279,37 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
+      "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.1.tgz",
+      "integrity": "sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -481,6 +513,18 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.5.tgz",
+      "integrity": "sha512-kwUxR7J9WLutBbulqg1dfOrMTwhMdXLdcGUhcbCcGwnPLt3gz19uHVdwH1syKVDbE022ZS2vZxOWflFLS0YTjw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.1.0",
+        "@emnapi/runtime": "^1.1.0",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -658,6 +702,152 @@
       "dependencies": {
         "@octokit/openapi-types": "^19.1.0"
       }
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-1.12.0.tgz",
+      "integrity": "sha512-wYe+dlF8npM7cwopOOxbdNjtmJp17e/xF5c0K2WooQXy5VOh74icydM33+Uh/SZDgwyum09/U1FVCX5GdeQk+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-1.12.0.tgz",
+      "integrity": "sha512-FZxxp99om+SlvBr1cjzF8A3TjYcS0BInCqjUlM+2f9m9bPTR2Bng9Zq5Q09ZQyrKJjfGKqlOEHs3akuVOnrx3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-1.12.0.tgz",
+      "integrity": "sha512-BZi0iU6IEOnXGSkqt1OjTTkN9wfyaK6kTpQwL/axl8eCcNDc7wbv1vloHgILf7ozAY1TP75nsLYlASYI4B5kGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.12.0.tgz",
+      "integrity": "sha512-L2qnMEnZAqxbG9b1J3di/w/THIm+1fMVfbbTMWIQNMMXdMeqqDN6ojnOLDtuP564rAh4TBFPdLyEfGhMz6ipNA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.12.0.tgz",
+      "integrity": "sha512-otVbS4zeo3n71zgGLBYRTriDzc0zpruC0WI3ICwjpIk454cLwGV0yzh4jlGYWQJYJk0BRAmXFd3ooKIF+bKBHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.12.0.tgz",
+      "integrity": "sha512-IStQDjIT7Lzmqg1i9wXvPL/NsYsxF24WqaQFS8b8rxra+z0VG7saBOsEnOaa4jcEY8MVpLYabFhTV+fSsA2vnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.12.0.tgz",
+      "integrity": "sha512-SipT7EVORz8pOQSFwemOm91TpSiBAGmOjG830/o+aLEsvQ4pEy223+SAnCfITh7+AahldYsJnVoIs519jmIlKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-1.12.0.tgz",
+      "integrity": "sha512-mGh0XfUzKdn+WFaqPacziNraCWL5znkHRfQVxG9avGS9zb2KC/N1EBbPzFqutDwixGDP54r2gx4q54YCJEZ4iQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-1.12.0.tgz",
+      "integrity": "sha512-SZN6v7apKmQf/Vwiqb6e/s3Y2Oacw8uW8V2i1AlxtyaEFvnFE0UBn89zq6swEwE3OCajNWs0yPvgAXUMddYc7Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.12.0.tgz",
+      "integrity": "sha512-GRe4bqCfFsyghruEn5bv47s9w3EWBdO2q72xCz5kpQ0LWbw+enPHtTjw3qX5PUcFYpKykM55FaO0hFDs1yzatw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.12.0.tgz",
+      "integrity": "sha512-Z3llHH0jfJP4mlWq3DT7bK6qV+/vYe0+xzCgfc67+Tc/U3eYndujl880bexeGdGNPh87JeYznpZAOJ44N7QVVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@pnpm/config.env-replace": {
       "version": "1.1.0",
@@ -1201,6 +1391,16 @@
         "@vue/compiler-sfc": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
+      "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/json5": {
@@ -2560,6 +2760,238 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-barrel-file-utils": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/eslint-barrel-file-utils/-/eslint-barrel-file-utils-0.0.11.tgz",
+      "integrity": "sha512-KoCm6mI39DMAoznpFqOeTyKi0k/PRY5PwdHKpXSdw2FMeZSQjvsJpaKrwWJAYjneRUWX6LAxA1d/26ozFj+U+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "eslint-barrel-file-utils-android-arm-eabi": "0.0.11",
+        "eslint-barrel-file-utils-android-arm64": "0.0.11",
+        "eslint-barrel-file-utils-darwin-arm64": "0.0.11",
+        "eslint-barrel-file-utils-darwin-x64": "0.0.11",
+        "eslint-barrel-file-utils-freebsd-x64": "0.0.11",
+        "eslint-barrel-file-utils-linux-arm-gnueabihf": "0.0.11",
+        "eslint-barrel-file-utils-linux-arm64-gnu": "0.0.11",
+        "eslint-barrel-file-utils-linux-arm64-musl": "0.0.11",
+        "eslint-barrel-file-utils-linux-x64-gnu": "0.0.11",
+        "eslint-barrel-file-utils-linux-x64-musl": "0.0.11",
+        "eslint-barrel-file-utils-win32-arm64-msvc": "0.0.11",
+        "eslint-barrel-file-utils-win32-ia32-msvc": "0.0.11",
+        "eslint-barrel-file-utils-win32-x64-msvc": "0.0.11"
+      }
+    },
+    "node_modules/eslint-barrel-file-utils-android-arm-eabi": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/eslint-barrel-file-utils-android-arm-eabi/-/eslint-barrel-file-utils-android-arm-eabi-0.0.11.tgz",
+      "integrity": "sha512-zvq2HCBwKzW4ya/sxXjbbyC4l1jo3kHnKdDoarjEmhrfTR27PNDfB9YWDQsW/fkwOnwtdcfbR9B9i+Mkw8JO6Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/eslint-barrel-file-utils-android-arm64": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/eslint-barrel-file-utils-android-arm64/-/eslint-barrel-file-utils-android-arm64-0.0.11.tgz",
+      "integrity": "sha512-rpNW1lqpGgM2MJfCWD6oEL4sioRmrGhXrRV9tncSU9soK4+KKQ5yBfOsG6lQgHDkcVhLVGMocZf8Z1zeVZ7V/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/eslint-barrel-file-utils-darwin-arm64": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/eslint-barrel-file-utils-darwin-arm64/-/eslint-barrel-file-utils-darwin-arm64-0.0.11.tgz",
+      "integrity": "sha512-U2Kyd7TQ9lpVTKPSLIsfujGQ66CVfIKBDVN71H+U2ub4x1WTiOcKBVmyqR+fEHrITHwJksyiucPo1nE1GCEPkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/eslint-barrel-file-utils-darwin-x64": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/eslint-barrel-file-utils-darwin-x64/-/eslint-barrel-file-utils-darwin-x64-0.0.11.tgz",
+      "integrity": "sha512-xvqwsJOQqHnYzP3P/3YYr2VjN4A114vR+i4Q/z8Zbd/DBgx4JWZWCdam01x16BbUvN05yRmB/eARWKUbGv1BbA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/eslint-barrel-file-utils-freebsd-x64": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/eslint-barrel-file-utils-freebsd-x64/-/eslint-barrel-file-utils-freebsd-x64-0.0.11.tgz",
+      "integrity": "sha512-NOjL2ZG1RWsRYyiDJlA1YqfZ1JNjbSh9uxTrFOTc6X5MFvgali8JL5PciGk2fYOjYFKYu7vQCfVnqpdyrGBW0g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/eslint-barrel-file-utils-linux-arm-gnueabihf": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/eslint-barrel-file-utils-linux-arm-gnueabihf/-/eslint-barrel-file-utils-linux-arm-gnueabihf-0.0.11.tgz",
+      "integrity": "sha512-4xzoigeh1U/GdZwqS8LDXtStW20njO6EkH4dy8jj3D0a5sG2o5cefteSa09sGuyIXiO8pyk5T+bjIE8tHnfqIw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/eslint-barrel-file-utils-linux-arm64-gnu": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/eslint-barrel-file-utils-linux-arm64-gnu/-/eslint-barrel-file-utils-linux-arm64-gnu-0.0.11.tgz",
+      "integrity": "sha512-8TG38orUFFUss8xMyT478x9BiEoBDm6OlqUzHF2Jgm6QLrTEOR+9aR+6fqWkOysNpiuf9LZigUemBM6e4RIw2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/eslint-barrel-file-utils-linux-arm64-musl": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/eslint-barrel-file-utils-linux-arm64-musl/-/eslint-barrel-file-utils-linux-arm64-musl-0.0.11.tgz",
+      "integrity": "sha512-p3dftf3t+YzfVVsO7jbjdbZHluX+B1JijYZLssSSqJfS2rliNmaCW1vdU+V9gJVy+wjEPlVENpKYEDBWqUWG3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/eslint-barrel-file-utils-linux-x64-gnu": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/eslint-barrel-file-utils-linux-x64-gnu/-/eslint-barrel-file-utils-linux-x64-gnu-0.0.11.tgz",
+      "integrity": "sha512-Yhok34OIE2fXIwV8+2sRySwiD4i/XRFXLbTS9objm6zr5BKZzVUeGOiiNuggZthgOn+eyV6t2oQw8PDoipuEJA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/eslint-barrel-file-utils-linux-x64-musl": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/eslint-barrel-file-utils-linux-x64-musl/-/eslint-barrel-file-utils-linux-x64-musl-0.0.11.tgz",
+      "integrity": "sha512-wpRUbOjMex3E9uxkGCn1JGiGZECLYqzAr3jWBP1jsDbB3yf9ebpFTJSG1635PJnwh0ECIoPtQcgn+cAqQDQqpQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/eslint-barrel-file-utils-win32-arm64-msvc": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/eslint-barrel-file-utils-win32-arm64-msvc/-/eslint-barrel-file-utils-win32-arm64-msvc-0.0.11.tgz",
+      "integrity": "sha512-/bjKmAMIUrw6EoCiyQXp6CDNh9GUAKjprjDIeCkG5EPuxaHveriCwNm94PelE+9WrnjqSaChxzBBpiss8fUxpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/eslint-barrel-file-utils-win32-ia32-msvc": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/eslint-barrel-file-utils-win32-ia32-msvc/-/eslint-barrel-file-utils-win32-ia32-msvc-0.0.11.tgz",
+      "integrity": "sha512-4uZRNeOGKYE15vpC8WR4Q9BTKSzl3lPnx8jBHuv2fDIhG+4XyJ6eT00Pg98Ydkk1NTlNlyqYgkmhGXqEF1FX+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/eslint-barrel-file-utils-win32-x64-msvc": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/eslint-barrel-file-utils-win32-x64-msvc/-/eslint-barrel-file-utils-win32-x64-msvc-0.0.11.tgz",
+      "integrity": "sha512-8F+UQZ52tX+yCLaq9fjFTDomP6ahrFsSVQzIRGUH1GSAIzw0B3+oEheEuYzNC9LIY7iizqTprgNTEjc6/KNGoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -2602,6 +3034,20 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-barrel-files": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-barrel-files/-/eslint-plugin-barrel-files-2.1.0.tgz",
+      "integrity": "sha512-NXeHXtFLZd6QGbS5af9tiwIoI+BVptHUcGkkF/ouvEPa+ZiZvK0xek4Yh6cd5jNDEg8P+tIA5xxB2ZC/RnqXyw==",
+      "license": "MIT",
+      "dependencies": {
+        "eslint-barrel-file-utils": "^0.0.11",
+        "oxc-resolver": "^1.9.3",
+        "requireindex": "^1.2.0"
+      },
+      "peerDependencies": {
+        "eslint": ">= 5"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -7776,6 +8222,28 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/oxc-resolver": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-1.12.0.tgz",
+      "integrity": "sha512-YlaCIArvWNKCWZFRrMjhh2l5jK80eXnpYP+bhRc1J/7cW3TiyEY0ngJo73o/5n8hA3+4yLdTmXLNTQ3Ncz50LQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-darwin-arm64": "1.12.0",
+        "@oxc-resolver/binding-darwin-x64": "1.12.0",
+        "@oxc-resolver/binding-freebsd-x64": "1.12.0",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "1.12.0",
+        "@oxc-resolver/binding-linux-arm64-gnu": "1.12.0",
+        "@oxc-resolver/binding-linux-arm64-musl": "1.12.0",
+        "@oxc-resolver/binding-linux-x64-gnu": "1.12.0",
+        "@oxc-resolver/binding-linux-x64-musl": "1.12.0",
+        "@oxc-resolver/binding-wasm32-wasi": "1.12.0",
+        "@oxc-resolver/binding-win32-arm64-msvc": "1.12.0",
+        "@oxc-resolver/binding-win32-x64-msvc": "1.12.0"
+      }
+    },
     "node_modules/p-each-series": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
@@ -8331,6 +8799,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.5"
       }
     },
     "node_modules/resolve": {
@@ -9264,6 +9741,13 @@
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
+      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/src/package.json
+++ b/src/package.json
@@ -45,6 +45,7 @@
     "@typescript-eslint/eslint-plugin": "^8.4.0",
     "@typescript-eslint/parser": "^8.4.0",
     "eslint": "^8.57.0",
+    "eslint-plugin-barrel-files": "^2.1.0",
     "eslint-plugin-import": "^2.30.0",
     "eslint-plugin-jest": "^28.8.2",
     "eslint-plugin-react": "^7.35.1",


### PR DESCRIPTION
BREAKING CHANGE: avoid barrel files

Add eslint plugin to avoid big barrel files

https://www.npmjs.com/package/eslint-plugin-barrel-files

The proposal is to delete the largest barrel files to optimize the application's loading in development and tests execution.

Some references that will help to understand the problem with barrel files:

https://vite.dev/guide/performance#avoid-barrel-files

https://vercel.com/blog/how-we-optimized-package-imports-in-next-js

https://laniewski.me/blog/pitfalls-of-barrel-files-in-javascript-modules/

https://dev.to/twynsicle/why-is-my-jest-test-suite-so-slow-1od

https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7/

https://tkdodo.eu/blog/please-stop-using-barrel-files