### PR TITLE
ci: enable npm trusted publishing

### DIFF
--- a/.github/scripts/publish.sh
+++ b/.github/scripts/publish.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+# Get the latest tag before semantic-release
+PREVIOUS_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+echo "Previous release tag: ${PREVIOUS_TAG:-<none>}"
+
+npx semantic-release
+
+# Get the latest tag after semantic-release
+CURRENT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+echo "Current release tag: ${CURRENT_TAG:-<none>}"
+
+# If semantic-release created a new version,
+# publish it to npm with OIDC (Trusted Publishing)
+if [ "$PREVIOUS_TAG" != "$CURRENT_TAG" ]; then
+  echo "New release detected (${CURRENT_TAG}). Publishing to npm..."
+  npm publish
+else
+  echo "No new release detected. Skipping npm publish."
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      id-token: write  # Required for OIDC trusted publishing
+      contents: read   # Required for checkout
     steps:
       - name: "Generate token"
         id: generate_token
@@ -33,17 +36,19 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
 
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 
       - name: Publish package to NPM
-        run: npx semantic-release
+        run: bash .github/scripts/publish.sh
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Recently we rotated npm classic tokens due to a policy change from npmjs.com and after the rotation, the publish step is failing.

In order to fix it, we are trying to enable [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) which enables the publish of npm packages directly from CI/CD using [OpenID Connect (OIDC)](https://openid.net/developers/how-connect-works/) authentication.