### PR TITLE
ci: use absolute path for release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,6 @@ jobs:
         run: npm ci
 
       - name: Publish package to NPM
-        run: bash .github/scripts/publish.sh
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/publish.sh"
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Fixes execution error when running the release script because the workdir is "src" instead of root dir.