### PR TITLE
ci: fix trusted publishing

### DIFF
--- a/src/.releaserc.json
+++ b/src/.releaserc.json
@@ -13,7 +13,12 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/npm",
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": false
+      }
+    ],
     "@semantic-release/github",
     [
       "@semantic-release/git",

--- a/src/package.json
+++ b/src/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@semantic-release/git": "^10.0.1",
+    "@semantic-release/npm": "^12.0.0",
     "semantic-release": "^23.0.0"
   },
   "publishConfig": {


### PR DESCRIPTION
Fix Trusted Publishing workflow by enforcing version >12 of semantic-release/npm and configuring it to not publishing to npm (additional separated step is in charge of publishing the package).