### PR TITLE
feat: enforce react/no-danger to prevent unsanitized dangerouslySetIn…

### DIFF
--- a/src/eslint.config.js
+++ b/src/eslint.config.js
@@ -143,6 +143,7 @@ module.exports = [
     rules: {
       'react/prop-types': 'off', // Since we use TypeScript for type checking
       'react/react-in-jsx-scope': 'off', // Not needed with React 17+
+      'react/no-danger': 'error',
     },
   },
 


### PR DESCRIPTION
## What
- Add `react/no-danger: 'error'` to the React-specific config block
- This enforces that `dangerouslySetInnerHTML` cannot be used directly in JSX

## Why
Direct use of `dangerouslySetInnerHTML` without sanitization is an XSS vector. By enforcing this rule at the shared config level, all projects using `@landbot/eslint-config-typescript-react` are protected by default. The intended pattern is to wrap any HTML rendering in a sanitization component (e.g. a `SafeHTML` wrapper that runs DOMPurify before rendering).

## How to test
After upgrading to the new version, adding `<div dangerouslySetInnerHTML={{ __html: someVar }} />` to any `.jsx`/`.tsx` file should produce an ESLint error:
```
Dangerous property 'dangerouslySetInnerHTML' found  react/no-danger
```
